### PR TITLE
Mention moment.js dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # react-datetime-range-picker
 
-This is a datetime range picker based off of [react-datetime](https://github.com/YouCanBookMe/react-datetime). It is highly customizable and isn't dependent on jQuery.
+This is a datetime range picker based off of [react-datetime](https://github.com/YouCanBookMe/react-datetime). It is highly customizable and isn't dependent on jQuery (but it does require Moment).
 
 ## Installation
 


### PR DESCRIPTION
https://github.com/wojtekmaj/react-daterange-picker and some other date range picker libraries don't require moment (but they aren't dateTIME range pickers either)