### PR TITLE
Allow startDate and endDate to be altered

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,10 @@ Almost all the props available for [react-datetime](https://github.com/YouCanBoo
 
 | Name | Type | Default | Description |
 |------|------|---------|-------------|
-| startDate | `Date` | `new Date()` | This sets the initial start date |
-| endDate | `Date` | `new Date()` | This sets the initial end date |
+| defaultStartDate | `Date` | `new Date()` | This sets the default/initial start date |
+| defaultEndDate | `Date` | `new Date()` | This sets the default/initial end date |
+| startDate | `Date` | `new Date()` | This sets a new value for the start date |
+| endDate | `Date` | `new Date()` | This sets a new value for the end date |
 | dateFormat | `Boolean` or `String` | `true` | Defines the format for the date. It accepts any `Moment` date format (not in localized format). If `true` the date will be displayed using the defaults for the current `locale`. If `false` the datepicker is disabled and the component can be used as timepicker. |
 | timeFormat | `Boolean` or `String` | `true` | Defines the format for the time. It accepts any `Moment` time format (not in localized format). If `true` the time will be displayed using the defaults for the current `locale`. If `false` the timepicker is disabled and the component can be used as datepicker. |
 | utc | `boolean` | `false` | When true, start and end time values will be interpreted as UTC. Otherwise they will default to the user's local timezone. |

--- a/README.md
+++ b/README.md
@@ -33,10 +33,8 @@ Almost all the props available for [react-datetime](https://github.com/YouCanBoo
 
 | Name | Type | Default | Description |
 |------|------|---------|-------------|
-| defaultStartDate | `Date` | `new Date()` | This sets the default/initial start date |
-| defaultEndDate | `Date` | `new Date()` | This sets the default/initial end date |
-| startDate | `Date` | `new Date()` | This sets a new value for the start date |
-| endDate | `Date` | `new Date()` | This sets a new value for the end date |
+| startDate | `Date` | `new Date()` | This sets a value for the start date |
+| endDate | `Date` | `new Date()` | This sets a value for the end date |
 | dateFormat | `Boolean` or `String` | `true` | Defines the format for the date. It accepts any `Moment` date format (not in localized format). If `true` the date will be displayed using the defaults for the current `locale`. If `false` the datepicker is disabled and the component can be used as timepicker. |
 | timeFormat | `Boolean` or `String` | `true` | Defines the format for the time. It accepts any `Moment` time format (not in localized format). If `true` the time will be displayed using the defaults for the current `locale`. If `false` the timepicker is disabled and the component can be used as datepicker. |
 | utc | `boolean` | `false` | When true, start and end time values will be interpreted as UTC. Otherwise they will default to the user's local timezone. |

--- a/lib/index.jsx
+++ b/lib/index.jsx
@@ -15,17 +15,20 @@ class DatetimeRangePicker extends Component {
     this.state = {
       start: moment(props.startDate) || moment(),
       end: moment(props.endDate) || moment(),
-      startDate: moment(props.startDate) || moment(),
-      endDate: moment(props.endDate) || moment(),
+      startDate: props.startDate,
+      endDate: props.endDate,
     };
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {
-    const newStartDate = moment(nextProps.startDate);
-    const newEndDate = moment(nextProps.endDate);
-    return newStartDate.isSame(prevState.startDate) && newEndDate.isSame(prevState.endDate)
+    return nextProps.startDate === prevState.startDate && nextProps.endDate === prevState.endDate
       ? {}
-      : { start: newStartDate, end: newEndDate, startDate: newStartDate, endDate: newEndDate }
+      : { 
+          start: moment(nextProps.startDate), 
+          end: moment(nextProps.endDate), 
+          startDate: nextProps.startDate, 
+          endDate: nextProps.endDate, 
+        }
   }
 
   getInputProps() {
@@ -76,6 +79,7 @@ class DatetimeRangePicker extends Component {
     return {
       ...baseProps,
       ...inputProps,
+      defaultValue: this.props.defaultStartDate,
       value: this.state.start,
       onBlur: this.props.onStartDateBlur,
       onFocus: this.props.onStartDateFocus,
@@ -91,6 +95,7 @@ class DatetimeRangePicker extends Component {
       ...baseProps,
       ...inputProps,
       onBlur: this.props.onEndDateBlur,
+      defaultValue: this.props.defaultEndDate,
       value: this.state.end,
       onFocus: this.props.onEndDateFocus,
       timeConstraints: this.props.endTimeConstraints,
@@ -233,9 +238,11 @@ DatetimeRangePicker.propTypes = {
   onStartDateFocus: PropTypes.func,
   onStartDateChange: PropTypes.func,
   pickerClassName: PropTypes.string,
+  defaultEndDate: PropTypes.oneOfType([PropTypes.instanceOf(moment), PropTypes.instanceOf(Date)]),
   endDate: PropTypes.oneOfType([PropTypes.instanceOf(moment), PropTypes.instanceOf(Date)]),
   endTimeConstraints: PropTypes.object,   // eslint-disable-line
   startDate: PropTypes.oneOfType([PropTypes.instanceOf(moment), PropTypes.instanceOf(Date)]),
+  defaultStartDate: PropTypes.oneOfType([PropTypes.instanceOf(moment), PropTypes.instanceOf(Date)]),
   startTimeConstraints: PropTypes.object,   // eslint-disable-line
   dateFormat: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
   timeFormat: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),

--- a/lib/index.jsx
+++ b/lib/index.jsx
@@ -15,7 +15,17 @@ class DatetimeRangePicker extends Component {
     this.state = {
       start: moment(props.startDate) || moment(),
       end: moment(props.endDate) || moment(),
+      startDate: moment(props.startDate) || moment(),
+      endDate: moment(props.endDate) || moment(),
     };
+  }
+
+  static getDerivedStateFromProps(nextProps, prevState) {
+    const newStartDate = moment(nextProps.startDate);
+    const newEndDate = moment(nextProps.endDate);
+    return newStartDate.isSame(prevState.startDate) && newEndDate.isSame(prevState.endDate)
+      ? {}
+      : { start: newStartDate, end: newEndDate, startDate: newStartDate, endDate: newEndDate }
   }
 
   getInputProps() {
@@ -66,7 +76,7 @@ class DatetimeRangePicker extends Component {
     return {
       ...baseProps,
       ...inputProps,
-      defaultValue: this.props.startDate,
+      value: this.state.start,
       onBlur: this.props.onStartDateBlur,
       onFocus: this.props.onStartDateFocus,
       timeConstraints: this.props.startTimeConstraints,
@@ -81,7 +91,7 @@ class DatetimeRangePicker extends Component {
       ...baseProps,
       ...inputProps,
       onBlur: this.props.onEndDateBlur,
-      defaultValue: this.props.endDate,
+      value: this.state.end,
       onFocus: this.props.onEndDateFocus,
       timeConstraints: this.props.endTimeConstraints,
     };
@@ -223,9 +233,9 @@ DatetimeRangePicker.propTypes = {
   onStartDateFocus: PropTypes.func,
   onStartDateChange: PropTypes.func,
   pickerClassName: PropTypes.string,
-  endDate: PropTypes.oneOfType([PropTypes.instanceOf(Moment), PropTypes.instanceOf(Date)]),
+  endDate: PropTypes.oneOfType([PropTypes.instanceOf(moment), PropTypes.instanceOf(Date)]),
   endTimeConstraints: PropTypes.object,   // eslint-disable-line
-  startDate: PropTypes.oneOfType([PropTypes.instanceOf(Moment), PropTypes.instanceOf(Date)]),
+  startDate: PropTypes.oneOfType([PropTypes.instanceOf(moment), PropTypes.instanceOf(Date)]),
   startTimeConstraints: PropTypes.object,   // eslint-disable-line
   dateFormat: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
   timeFormat: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),

--- a/lib/index.jsx
+++ b/lib/index.jsx
@@ -13,10 +13,10 @@ class DatetimeRangePicker extends Component {
     super(props);
 
     this.state = {
-      start: moment(props.startDate) || moment(),
-      end: moment(props.endDate) || moment(),
-      startDate: props.startDate,
-      endDate: props.endDate,
+      start: null,
+      end: null,
+      startDate: null,
+      endDate: null,
     };
   }
 
@@ -24,8 +24,8 @@ class DatetimeRangePicker extends Component {
     return nextProps.startDate === prevState.startDate && nextProps.endDate === prevState.endDate
       ? {}
       : { 
-          start: moment(nextProps.startDate), 
-          end: moment(nextProps.endDate), 
+          start: moment(nextProps.startDate) || moment(), 
+          end: moment(nextProps.endDate) || moment(), 
           startDate: nextProps.startDate, 
           endDate: nextProps.endDate, 
         }
@@ -79,7 +79,6 @@ class DatetimeRangePicker extends Component {
     return {
       ...baseProps,
       ...inputProps,
-      defaultValue: this.props.defaultStartDate,
       value: this.state.start,
       onBlur: this.props.onStartDateBlur,
       onFocus: this.props.onStartDateFocus,
@@ -95,7 +94,6 @@ class DatetimeRangePicker extends Component {
       ...baseProps,
       ...inputProps,
       onBlur: this.props.onEndDateBlur,
-      defaultValue: this.props.defaultEndDate,
       value: this.state.end,
       onFocus: this.props.onEndDateFocus,
       timeConstraints: this.props.endTimeConstraints,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-datetime-range-picker",
-  "description": "Resusable date time range picker",
-  "version": "1.0.6",
+  "description": "Reusable date time range picker",
+  "version": "1.0.7",
   "author": "Samuel Amoah <sa.am@programmer.net>",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "prop-types": "^15.5.10"
   },
   "peerDependencies": {
-    "react": "^15.6.1",
+    "react": "^16.3.0",
     "react-datetime": "^2.8.10"
   },
   "scripts": {


### PR DESCRIPTION
Allow startDate and endDate to be altered even after the component DatetimeRangePicker is initialized: this.state.start and this.state.end will derived from the props startDate and endDate (getDerivedStateFromProps).