### PR TITLE
Make this work in a vite project

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "peerDependencies": {
     "react": "^16.3.0",
-    "react-datetime": "^2.8.10"
+    "react-datetime": "^3.2.0"
   },
   "scripts": {
     "prepublish": "npm run compile",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react-datetime": "^3.2.0"
   },
   "scripts": {
+    "prepare": "npm run compile",
     "prepublish": "npm run compile",
     "test": "npm run compile && babel-tape-runner test/*.js",
     "compile": "npm run lint && babel lib --out-dir dist --copy-files",


### PR DESCRIPTION
With older version of react-datetime we get the error - `moment is not a function`. Upgrading version of react-datetime fixes this issue.